### PR TITLE
Track spans for HIR nodes and resolver

### DIFF
--- a/crates/keyton_rust_compiler/src/lib.rs
+++ b/crates/keyton_rust_compiler/src/lib.rs
@@ -6,3 +6,4 @@ pub mod rhir;
 pub mod rust_codegen;
 pub mod shir;
 pub mod thir;
+pub mod span;

--- a/crates/keyton_rust_compiler/src/span.rs
+++ b/crates/keyton_rust_compiler/src/span.rs
@@ -1,0 +1,23 @@
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl Span {
+    pub fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Spanned<T> {
+    pub node: T,
+    pub span: Span,
+}
+
+impl<T> Spanned<T> {
+    pub fn new(node: T, span: Span) -> Self {
+        Self { node, span }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Span` struct and utility `Spanned` wrapper
- track spans during lowering and expose `lower_program_with_spans`
- report spans in `ResolveError::UnresolvedName` and support resolving with span maps
- test unresolved name includes span data

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68acc7735efc832c89eb34d4bddb57b8