### PR TITLE
Implement for loops and test functionality

### DIFF
--- a/crates/kayton_interactive_shared/tests/for_loop_test.rs
+++ b/crates/kayton_interactive_shared/tests/for_loop_test.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+use kayton_interactive_shared::{InteractiveState, execute_prepared, prepare_input};
+
+#[test]
+fn for_loop_sums_to_three() -> Result<()> {
+    let mut state = InteractiveState::new();
+
+    let code = r#"n = 2
+s = 0
+for x in 0..n:
+    s += x
+"#;
+
+    let prepared = prepare_input(&mut state, code)?;
+    execute_prepared(&mut state, &prepared)?;
+
+    // Fetch the reported value of s from the VM
+    let s_text = if let Some(h) = state.vm().resolve_name("s") {
+        state.vm_mut().format_value_by_handle(h).unwrap_or_default()
+    } else {
+        String::new()
+    };
+    assert_eq!(s_text, "3");
+
+    Ok(())
+}
+

--- a/crates/keyton_rust_compiler/src/hir/hir_types.rs
+++ b/crates/keyton_rust_compiler/src/hir/hir_types.rs
@@ -12,6 +12,13 @@ pub enum HirStmt {
         hir_id: HirId,
         expr: HirExpr,
     },
+    ForRange {
+        hir_id: HirId,
+        var: String,
+        start: HirExpr,
+        end: HirExpr,
+        body: Vec<HirStmt>,
+    },
     FuncDef {
         hir_id: HirId,
         name: String,

--- a/crates/keyton_rust_compiler/src/hir/mod.rs
+++ b/crates/keyton_rust_compiler/src/hir/mod.rs
@@ -47,6 +47,13 @@ fn lower_stmt(ctx: &mut LoweringCtx, stmt: Stmt) -> HirStmt {
             name,
             expr: lower_expr(ctx, expr),
         },
+        Stmt::ForRange { var, start, end, body } => HirStmt::ForRange {
+            hir_id: ctx.new_id(),
+            var,
+            start: lower_expr(ctx, start),
+            end: lower_expr(ctx, end),
+            body: body.into_iter().map(|s| lower_stmt(ctx, s)).collect(),
+        },
         Stmt::ExprStmt(expr) => HirStmt::ExprStmt {
             hir_id: ctx.new_id(),
             expr: lower_expr(ctx, expr),

--- a/crates/keyton_rust_compiler/src/rhir/converter.rs
+++ b/crates/keyton_rust_compiler/src/rhir/converter.rs
@@ -63,6 +63,19 @@ impl<'a> Converter<'a> {
                 hir_id: *hir_id,
                 expr: self.convert_expr(expr),
             },
+            TStmt::ForRange {
+                hir_id,
+                sym,
+                start,
+                end,
+                body,
+            } => RStmt::ForRange {
+                hir_id: *hir_id,
+                sym: *sym,
+                start: self.convert_expr(start),
+                end: self.convert_expr(end),
+                body: body.iter().map(|st| self.convert_stmt(st)).collect(),
+            },
         }
     }
 

--- a/crates/keyton_rust_compiler/src/rhir/types.rs
+++ b/crates/keyton_rust_compiler/src/rhir/types.rs
@@ -12,6 +12,13 @@ pub enum RStmt {
         hir_id: HirId,
         expr: RExpr,
     },
+    ForRange {
+        hir_id: HirId,
+        sym: SymbolId,
+        start: RExpr,
+        end: RExpr,
+        body: Vec<RStmt>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/keyton_rust_compiler/src/rust_codegen/generator.rs
+++ b/crates/keyton_rust_compiler/src/rust_codegen/generator.rs
@@ -161,6 +161,24 @@ impl<'a> CodeGenerator<'a> {
                 let expr_str = self.convert_expr_to_string(expr);
                 format!("{};", expr_str)
             }
+            RStmt::ForRange { sym, start, end, body, .. } => {
+                let var_name = self.get_or_create_var_name(*sym);
+                let start_str = self.convert_expr_to_string(start);
+                let end_str = self.convert_expr_to_string(end);
+                // Emit body statements with relative indentation (4 spaces). The caller adds the base indent.
+                let mut out = String::new();
+                out.push_str(&format!("for {} in {}..{} {{\n", var_name, start_str, end_str));
+                for inner in body {
+                    if self.should_skip_stmt(inner) {
+                        continue;
+                    }
+                    out.push_str("    "); // 4 spaces relative to the block
+                    out.push_str(&self.convert_stmt_to_string(inner));
+                    out.push_str("\n");
+                }
+                out.push_str("}");
+                out
+            }
         }
     }
 

--- a/crates/keyton_rust_compiler/src/shir/types.rs
+++ b/crates/keyton_rust_compiler/src/shir/types.rs
@@ -12,6 +12,13 @@ pub enum SStmt {
         hir_id: HirId,
         expr: SExpr,
     },
+    ForRange {
+        hir_id: HirId,
+        sym: SymbolId,
+        start: SExpr,
+        end: SExpr,
+        body: Vec<SStmt>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/keyton_rust_compiler/src/thir/checker.rs
+++ b/crates/keyton_rust_compiler/src/thir/checker.rs
@@ -106,6 +106,33 @@ impl<'a> Checker<'a> {
                     expr: texpr,
                 }
             }
+            SStmt::ForRange {
+                hir_id,
+                sym,
+                start,
+                end,
+                body,
+            } => {
+                // start and end must be Int
+                let tstart = self.check_expr(start);
+                let tend = self.check_expr(end);
+                self.require(*hir_id, Type::Int, tstart.ty().clone());
+                self.require(*hir_id, Type::Int, tend.ty().clone());
+
+                // Loop variable is Int in the loop body scope; for simplicity, set its type
+                self.var_types.insert(*sym, Type::Int);
+
+                // Typecheck body statements
+                let body_t: Vec<TStmt> = body.iter().map(|st| self.check_stmt(st)).collect();
+
+                TStmt::ForRange {
+                    hir_id: *hir_id,
+                    sym: *sym,
+                    start: tstart,
+                    end: tend,
+                    body: body_t,
+                }
+            }
         }
     }
 

--- a/crates/keyton_rust_compiler/src/thir/types.rs
+++ b/crates/keyton_rust_compiler/src/thir/types.rs
@@ -12,6 +12,13 @@ pub enum TStmt {
         hir_id: HirId,
         expr: TExpr,
     },
+    ForRange {
+        hir_id: HirId,
+        sym: SymbolId,
+        start: TExpr,
+        end: TExpr,
+        body: Vec<TStmt>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
Add `for` loops with range syntax and the `+=` operator to the language, including a new test case.

The `+=` operator is desugared into an assignment with addition (`x = x + y`) during parsing. The `for` loop construct is implemented end-to-end through all compiler stages (lexer, parser, HIR, SHIR, THIR, RHIR, codegen) and includes updates to the interactive symbol analysis to correctly track variables within loop bodies.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fe8cfc5-7c27-4ca1-9c31-d9ce0f7bb718">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fe8cfc5-7c27-4ca1-9c31-d9ce0f7bb718">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

