### PR TITLE
Introduce new variable syntax and rename Int to I64

### DIFF
--- a/crates/kayton_interactive_shared/src/lib.rs
+++ b/crates/kayton_interactive_shared/src/lib.rs
@@ -221,7 +221,7 @@ pub fn prepare_input(
     for (name, kind) in state.globals.iter() {
         let ty = match kind {
             VarKind::Str => keyton_rust_compiler::shir::sym::Type::Str,
-            VarKind::Int => keyton_rust_compiler::shir::sym::Type::Int,
+            VarKind::Int => keyton_rust_compiler::shir::sym::Type::I64,
         };
         predeclared.push((name.clone(), ty));
     }

--- a/crates/keyton_rust_compiler/src/lexer/mod.rs
+++ b/crates/keyton_rust_compiler/src/lexer/mod.rs
@@ -7,6 +7,7 @@ pub enum Token {
     Int(i64),
     Str(String),
     Ident(String),
+    LetKw,
     FnKw,
     ReturnKw,
     Plus,
@@ -231,6 +232,7 @@ impl<'a> Lexer<'a> {
             }
         }
         match ident.as_str() {
+            "let" => Token::LetKw,
             "fn" => Token::FnKw,
             "return" => Token::ReturnKw,
             "for" => Token::ForKw,

--- a/crates/keyton_rust_compiler/src/parser/mod.rs
+++ b/crates/keyton_rust_compiler/src/parser/mod.rs
@@ -89,6 +89,22 @@ impl Parser {
         if self.is_at_end() {
             return None;
         }
+        // Let declaration (desugars to assignment)
+        if matches!(self.peek(), Token::LetKw) {
+            self.advance(); // 'let'
+            let name = match self.advance() {
+                Token::Ident(s) => s,
+                other => panic!("expected identifier after let, found {:?}", other),
+            };
+            self.expect(Token::Colon);
+            match self.advance() {
+                Token::Ident(s) if s == "i64" => {},
+                other => panic!("expected type 'i64' after colon in let, found {:?}", other),
+            }
+            self.expect(Token::Equal);
+            let expr = self.parse_expr();
+            return Some(Stmt::Assign { name, expr });
+        }
         // For loop
         if matches!(self.peek(), Token::ForKw) {
             return Some(self.parse_for_range());

--- a/crates/keyton_rust_compiler/src/parser/tests.rs
+++ b/crates/keyton_rust_compiler/src/parser/tests.rs
@@ -140,3 +140,25 @@ fn function_with_implicit_return() {
         }]
     );
 }
+
+#[test]
+fn let_syntax_ast() {
+    let input = r#"let x: i64 = 12
+print(x)
+"#;
+    let tokens = Lexer::new(input).tokenize();
+    let ast = Parser::new(tokens).parse_program();
+    assert_eq!(
+        ast,
+        vec![
+            Stmt::Assign {
+                name: "x".to_string(),
+                expr: Expr::Int(12),
+            },
+            Stmt::ExprStmt(Expr::Call {
+                func: Box::new(Expr::Ident("print".to_string())),
+                args: vec![Expr::Ident("x".to_string())],
+            }),
+        ]
+    );
+}

--- a/crates/keyton_rust_compiler/src/rhir/tests.rs
+++ b/crates/keyton_rust_compiler/src/rhir/tests.rs
@@ -43,7 +43,7 @@ print(x)
                 expr: RExpr::Int {
                     hir_id: HirId(2),
                     value: 12,
-                    ty: Type::Int,
+                    ty: Type::I64,
                 },
             },
             RStmt::Assign {
@@ -54,15 +54,15 @@ print(x)
                     left: Box::new(RExpr::Name {
                         hir_id: HirId(5),
                         sym: SymbolId(1),
-                        ty: Type::Int,
+                        ty: Type::I64,
                     }),
                     op: HirBinOp::Add,
                     right: Box::new(RExpr::Int {
                         hir_id: HirId(6),
                         value: 1,
-                        ty: Type::Int,
+                        ty: Type::I64,
                     }),
-                    ty: Type::Int,
+                    ty: Type::I64,
                 },
             },
             RStmt::ExprStmt {
@@ -73,7 +73,7 @@ print(x)
                     args: vec![RExpr::Name {
                         hir_id: HirId(10),
                         sym: SymbolId(1),
-                        ty: Type::Int,
+                        ty: Type::I64,
                     }],
                     ty: Type::Unit,
                 },
@@ -82,7 +82,7 @@ print(x)
     );
 
     // Var types snapshot includes x: Int
-    assert_eq!(rust_program.var_types.get(&SymbolId(1)), Some(&Type::Int));
+    assert_eq!(rust_program.var_types.get(&SymbolId(1)), Some(&Type::I64));
 }
 
 #[test]
@@ -123,7 +123,7 @@ print(x)
                 expr: RExpr::Int {
                     hir_id: HirId(2),
                     value: 12,
-                    ty: Type::Int,
+                    ty: Type::I64,
                 },
             },
             RStmt::Assign {
@@ -152,7 +152,7 @@ print(x)
     );
 
     // Var type snapshot: x(1): Int, x(2): Str
-    assert_eq!(rust_program.var_types.get(&SymbolId(1)), Some(&Type::Int));
+    assert_eq!(rust_program.var_types.get(&SymbolId(1)), Some(&Type::I64));
     assert_eq!(rust_program.var_types.get(&SymbolId(2)), Some(&Type::Str));
 }
 
@@ -217,7 +217,7 @@ print(f"{x}")
                 expr: RExpr::Int {
                     hir_id: HirId(2),
                     value: 12,
-                    ty: Type::Int,
+                    ty: Type::I64,
                 },
             },
             RStmt::ExprStmt {
@@ -237,7 +237,7 @@ print(f"{x}")
                                 expr: RExpr::Name {
                                     hir_id: HirId(9),
                                     sym: SymbolId(1),
-                                    ty: Type::Int,
+                                    ty: Type::I64,
                                 },
                             },
                             RStringPart::Text {
@@ -290,7 +290,7 @@ print(x)
                 expr: RExpr::Int {
                     hir_id: HirId(2),
                     value: 12,
-                    ty: Type::Int,
+                    ty: Type::I64,
                 },
             },
             RStmt::Assign {
@@ -299,7 +299,7 @@ print(x)
                 expr: RExpr::Int {
                     hir_id: HirId(4),
                     value: 42,
-                    ty: Type::Int,
+                    ty: Type::I64,
                 },
             },
             RStmt::ExprStmt {
@@ -310,7 +310,7 @@ print(x)
                     args: vec![RExpr::Name {
                         hir_id: HirId(8),
                         sym: SymbolId(1), // Uses the same x (SymbolId(1))
-                        ty: Type::Int,
+                        ty: Type::I64,
                     }],
                     ty: Type::Unit,
                 },
@@ -319,7 +319,7 @@ print(x)
     );
 
     // Var type snapshot: x(1): Int (same symbol reused)
-    assert_eq!(rust_program.var_types.get(&SymbolId(1)), Some(&Type::Int));
+    assert_eq!(rust_program.var_types.get(&SymbolId(1)), Some(&Type::I64));
 }
 
 #[test]

--- a/crates/keyton_rust_compiler/src/rust_codegen/generator.rs
+++ b/crates/keyton_rust_compiler/src/rust_codegen/generator.rs
@@ -121,7 +121,7 @@ impl<'a> CodeGenerator<'a> {
         // Also report the captured last expression value if any
         if let Some((_, ty)) = last_expr_idx {
             match ty {
-                Type::Int => {
+                Type::I64 => {
                     source_code
                         .push_str("    unsafe { report_int(\"__last\", __kayton_last as i64); }\n");
                 }

--- a/crates/keyton_rust_compiler/src/shir/sym.rs
+++ b/crates/keyton_rust_compiler/src/shir/sym.rs
@@ -16,7 +16,7 @@ pub enum SymKind {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Type {
-    Int,
+    I64,
     Str,
     Unit,
     Any,

--- a/crates/keyton_rust_compiler/src/thir/checker.rs
+++ b/crates/keyton_rust_compiler/src/thir/checker.rs
@@ -113,14 +113,14 @@ impl<'a> Checker<'a> {
                 end,
                 body,
             } => {
-                // start and end must be Int
+                // start and end must be I64
                 let tstart = self.check_expr(start);
                 let tend = self.check_expr(end);
-                self.require(*hir_id, Type::Int, tstart.ty().clone());
-                self.require(*hir_id, Type::Int, tend.ty().clone());
+                self.require(*hir_id, Type::I64, tstart.ty().clone());
+                self.require(*hir_id, Type::I64, tend.ty().clone());
 
-                // Loop variable is Int in the loop body scope; for simplicity, set its type
-                self.var_types.insert(*sym, Type::Int);
+                // Loop variable is I64 in the loop body scope; for simplicity, set its type
+                self.var_types.insert(*sym, Type::I64);
 
                 // Typecheck body statements
                 let body_t: Vec<TStmt> = body.iter().map(|st| self.check_stmt(st)).collect();
@@ -141,7 +141,7 @@ impl<'a> Checker<'a> {
             SExpr::Int { hir_id, value } => TExpr::Int {
                 hir_id: *hir_id,
                 value: *value,
-                ty: Type::Int,
+                ty: Type::I64,
             },
             SExpr::Str { hir_id, value } => TExpr::Str {
                 hir_id: *hir_id,
@@ -182,10 +182,10 @@ impl<'a> Checker<'a> {
                 let (lhs_ty, rhs_ty) = (l.ty().clone(), r.ty().clone());
                 let out_ty = match op {
                     HirBinOp::Add => {
-                        // Keep it simple: only Int + Int => Int
-                        self.require(*hir_id, Type::Int, lhs_ty.clone());
-                        self.require(*hir_id, Type::Int, rhs_ty.clone());
-                        Type::Int
+                        // Keep it simple: only I64 + I64 => I64
+                        self.require(*hir_id, Type::I64, lhs_ty.clone());
+                        self.require(*hir_id, Type::I64, rhs_ty.clone());
+                        Type::I64
                     }
                 };
                 TExpr::Binary {

--- a/crates/keyton_rust_compiler/src/thir/tests.rs
+++ b/crates/keyton_rust_compiler/src/thir/tests.rs
@@ -41,7 +41,7 @@ print(x)
                 expr: TExpr::Int {
                     hir_id: HirId(2),
                     value: 12,
-                    ty: Type::Int,
+                    ty: Type::I64,
                 },
             },
             TStmt::Assign {
@@ -52,15 +52,15 @@ print(x)
                     left: Box::new(TExpr::Name {
                         hir_id: HirId(5),
                         sym: SymbolId(1),
-                        ty: Type::Int,
+                        ty: Type::I64,
                     }),
                     op: HirBinOp::Add,
                     right: Box::new(TExpr::Int {
                         hir_id: HirId(6),
                         value: 1,
-                        ty: Type::Int,
+                        ty: Type::I64,
                     }),
-                    ty: Type::Int,
+                    ty: Type::I64,
                 },
             },
             TStmt::ExprStmt {
@@ -75,7 +75,7 @@ print(x)
                     args: vec![TExpr::Name {
                         hir_id: HirId(10),
                         sym: SymbolId(1),
-                        ty: Type::Int,
+                        ty: Type::I64,
                     }],
                     ty: Type::Unit,
                 },
@@ -84,7 +84,7 @@ print(x)
     );
 
     // Var types snapshot includes x: Int
-    assert_eq!(typed.var_types.get(&SymbolId(1)), Some(&Type::Int));
+    assert_eq!(typed.var_types.get(&SymbolId(1)), Some(&Type::I64));
 }
 
 #[test]
@@ -124,7 +124,7 @@ print(x)
                 expr: TExpr::Int {
                     hir_id: HirId(2),
                     value: 12,
-                    ty: Type::Int,
+                    ty: Type::I64,
                 },
             },
             TStmt::Assign {
@@ -157,7 +157,7 @@ print(x)
     );
 
     // Var type snapshot: x(1): Int, x(2): Str
-    assert_eq!(typed.var_types.get(&SymbolId(1)), Some(&Type::Int));
+    assert_eq!(typed.var_types.get(&SymbolId(1)), Some(&Type::I64));
     assert_eq!(typed.var_types.get(&SymbolId(2)), Some(&Type::Str));
 }
 
@@ -224,7 +224,7 @@ print(f"{x}")
                 expr: TExpr::Int {
                     hir_id: HirId(2),
                     value: 12,
-                    ty: Type::Int,
+                    ty: Type::I64,
                 },
             },
             TStmt::ExprStmt {
@@ -248,7 +248,7 @@ print(f"{x}")
                                 expr: TExpr::Name {
                                     hir_id: HirId(9),
                                     sym: SymbolId(1),
-                                    ty: Type::Int,
+                                    ty: Type::I64,
                                 },
                             },
                             TStringPart::Text {
@@ -300,7 +300,7 @@ print(x)
                 expr: TExpr::Int {
                     hir_id: HirId(2),
                     value: 12,
-                    ty: Type::Int,
+                    ty: Type::I64,
                 },
             },
             TStmt::Assign {
@@ -309,7 +309,7 @@ print(x)
                 expr: TExpr::Int {
                     hir_id: HirId(4),
                     value: 42,
-                    ty: Type::Int,
+                    ty: Type::I64,
                 },
             },
             TStmt::ExprStmt {
@@ -324,7 +324,7 @@ print(x)
                     args: vec![TExpr::Name {
                         hir_id: HirId(8),
                         sym: SymbolId(1), // Uses the same x (SymbolId(1))
-                        ty: Type::Int,
+                        ty: Type::I64,
                     }],
                     ty: Type::Unit,
                 },
@@ -333,5 +333,5 @@ print(x)
     );
 
     // Var type snapshot: x(1): Int (same symbol reused)
-    assert_eq!(typed.var_types.get(&SymbolId(1)), Some(&Type::Int));
+    assert_eq!(typed.var_types.get(&SymbolId(1)), Some(&Type::I64));
 }


### PR DESCRIPTION
Introduce `let name: i64 = expr` syntax, desugaring it to an assignment, and rename the compiler's `Int` type to `I64`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4958bac5-ad8f-4ae6-be10-6a95655d6ef5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4958bac5-ad8f-4ae6-be10-6a95655d6ef5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

