### PR TITLE
Add for-loop summation test

### DIFF
--- a/crates/keyton_rust_compiler/src/compile_rust/tests.rs
+++ b/crates/keyton_rust_compiler/src/compile_rust/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use libloading::Library;
+use std::sync::Mutex;
 
 #[test]
 fn compile_and_run_print() {
@@ -46,4 +47,50 @@ print(z)
             lib.get(b"run").expect("find run symbol");
         func();
     }
+}
+
+static CAPTURED: Mutex<Vec<u8>> = Mutex::new(Vec::new());
+
+extern "C" fn report_int(_name_ptr: *const u8, _name_len: usize, _value: i64) {}
+
+extern "C" fn report_str(
+    name_ptr: *const u8,
+    name_len: usize,
+    str_ptr: *const u8,
+    str_len: usize,
+) {
+    unsafe {
+        let name = std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
+            .unwrap_or("");
+        if name == "__stdout" {
+            let s = std::slice::from_raw_parts(str_ptr, str_len);
+            CAPTURED.lock().unwrap().extend_from_slice(s);
+        }
+    }
+}
+
+#[test]
+fn compile_and_run_for_loop_sum() {
+    let src = r#"s = 0
+for x in 0..3:
+    s += x
+print(s)
+"#;
+    let lib_path = compile_lang_source_to_dylib(src).expect("compile to dylib");
+    unsafe {
+        let lib = Library::new(&lib_path).expect("load dylib");
+        let set_reporters: libloading::Symbol<unsafe extern "C" fn(
+            extern "C" fn(*const u8, usize, i64),
+            extern "C" fn(*const u8, usize, *const u8, usize),
+        )> = lib
+            .get(b"kayton_set_reporters")
+            .expect("find reporters symbol");
+        let run: libloading::Symbol<unsafe extern "C" fn()> =
+            lib.get(b"run").expect("find run symbol");
+        CAPTURED.lock().unwrap().clear();
+        set_reporters(report_int, report_str);
+        run();
+    }
+    let output = String::from_utf8(CAPTURED.lock().unwrap().clone()).expect("utf8");
+    assert_eq!(output.trim(), "3");
 }


### PR DESCRIPTION
## Summary
- add integration test ensuring a simple for-loop sums to 3

## Testing
- `cargo test -p keyton_rust_compiler -q`
- `cargo test -p kayton_interactive_shared --test for_loop_test -q` *(fails: assertion `left == right` failed, left: `"1"`, right: `"3"`)*

------
https://chatgpt.com/codex/tasks/task_e_68bcad7eb5d4832cae5dcd556dcede34