### PR TITLE
Support vector append and sum operations

### DIFF
--- a/crates/keyton_rust_compiler/src/lexer/mod.rs
+++ b/crates/keyton_rust_compiler/src/lexer/mod.rs
@@ -25,6 +25,11 @@ pub enum Token {
     InKw,
     DotDot,
     PlusEqual,
+    Dot,
+    LBracket,
+    RBracket,
+    LAngle,
+    RAngle,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -177,15 +182,30 @@ impl<'a> Lexer<'a> {
                 Token::Colon
             }
             '.' => {
-                // Possibly DotDot
+                // Possibly Dot or DotDot
                 self.chars.next();
                 if let Some('.') = self.chars.peek().copied() {
                     self.chars.next();
                     Token::DotDot
                 } else {
-                    // Unknown single '.' -> skip and continue
-                    self.next_token()
+                    Token::Dot
                 }
+            }
+            '[' => {
+                self.chars.next();
+                Token::LBracket
+            }
+            ']' => {
+                self.chars.next();
+                Token::RBracket
+            }
+            '<' => {
+                self.chars.next();
+                Token::LAngle
+            }
+            '>' => {
+                self.chars.next();
+                Token::RAngle
             }
             '0'..='9' => self.lex_number(ch),
             'a'..='z' | 'A'..='Z' | '_' => {

--- a/crates/keyton_rust_compiler/src/shir/resolver.rs
+++ b/crates/keyton_rust_compiler/src/shir/resolver.rs
@@ -119,7 +119,9 @@ impl Resolver {
                                 };
                                 self.syms.define(scope, name, kind);
                             }
-                            HirStmt::FuncDef { name, params, body, .. } => {
+                            HirStmt::FuncDef {
+                                name, params, body, ..
+                            } => {
                                 let sid = self.syms.define(scope, name, SymKind::Func);
                                 if let Some(info) = self.syms.infos.get_mut(sid.0 as usize) {
                                     info.sig = Some(FuncSig {
@@ -129,7 +131,10 @@ impl Resolver {
                                 }
                                 self.user_funcs.insert(
                                     sid,
-                                    UserFuncDef { params: params.clone(), body: body.clone() },
+                                    UserFuncDef {
+                                        params: params.clone(),
+                                        body: body.clone(),
+                                    },
                                 );
                             }
                             HirStmt::ExprStmt { .. } => {}
@@ -191,7 +196,13 @@ impl Resolver {
                     },
                 }
             }
-            HirStmt::ForRange { hir_id, var, start, end, body } => {
+            HirStmt::ForRange {
+                hir_id,
+                var,
+                start,
+                end,
+                body,
+            } => {
                 let scope = self.current_scope();
                 let sym = self
                     .syms
@@ -297,6 +308,39 @@ impl Resolver {
         }
         if let Some(&sid) = self.builtins.get(name) {
             return sid;
+        }
+        match name {
+            "vec" => {
+                let sid = self.add_builtin("vec");
+                if let Some(info) = self.syms.infos.get_mut(sid.0 as usize) {
+                    info.sig = Some(FuncSig {
+                        params: vec![],
+                        ret: Type::Any,
+                    });
+                }
+                return sid;
+            }
+            "append" => {
+                let sid = self.add_builtin("append");
+                if let Some(info) = self.syms.infos.get_mut(sid.0 as usize) {
+                    info.sig = Some(FuncSig {
+                        params: vec![Type::Any, Type::Any],
+                        ret: Type::Unit,
+                    });
+                }
+                return sid;
+            }
+            "sum" => {
+                let sid = self.add_builtin("sum");
+                if let Some(info) = self.syms.infos.get_mut(sid.0 as usize) {
+                    info.sig = Some(FuncSig {
+                        params: vec![Type::Any],
+                        ret: Type::I64,
+                    });
+                }
+                return sid;
+            }
+            _ => {}
         }
         let sid = self
             .syms


### PR DESCRIPTION
## Summary
- add lexer, parser, and resolver support for Vec literals and method-style calls
- generate Rust for vec creation, push, and sum
- test Vec append and sum with and without explicit type annotation

## Testing
- `cargo test`
- `cargo test -p keyton_rust_compiler --lib`

------
https://chatgpt.com/codex/tasks/task_e_68bd3411a4ac832c926b5ec22b1810f3