### PR TITLE
Add tests for KVec vec_types conversions

### DIFF
--- a/crates/kayton_api/tests/vec_types_boolean_test.rs
+++ b/crates/kayton_api/tests/vec_types_boolean_test.rs
@@ -1,0 +1,13 @@
+use kayton_api::kinds::KIND_BOOL;
+use kayton_api::vec_types::KVec;
+
+#[test]
+fn from_vec_bool_roundtrip() {
+    let expected = vec![true, false, true];
+    let kv = KVec::from_vec_bool(expected.clone());
+    assert_eq!(kv.len, expected.len());
+    assert_eq!(kv.capacity, expected.capacity());
+    assert_eq!(kv.kind, KIND_BOOL);
+    let back = kv.as_vec_bool().unwrap();
+    assert_eq!(back, expected);
+}

--- a/crates/kayton_api/tests/vec_types_core_test.rs
+++ b/crates/kayton_api/tests/vec_types_core_test.rs
@@ -1,0 +1,41 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use kayton_api::kinds::{KindId, KIND_U8};
+use kayton_api::vec_types::KVec;
+
+#[test]
+fn from_raw_sets_fields() {
+    let v = vec![1u8, 2, 3];
+    let ptr = v.as_ptr();
+    let len = v.len();
+    let cap = v.capacity();
+    {
+        let kv = KVec::from_raw(ptr, len, cap, KIND_U8);
+        assert_eq!(kv.ptr, ptr);
+        assert_eq!(kv.len, len);
+        assert_eq!(kv.capacity, cap);
+        assert_eq!(kv.kind, KIND_U8);
+        assert!(kv.drop_fn.is_none());
+    }
+    drop(v);
+}
+
+static DROPPED: AtomicBool = AtomicBool::new(false);
+
+fn mark_drop(_ptr: *const u8, _len: usize, _capacity: usize, _kind: KindId) {
+    DROPPED.store(true, Ordering::SeqCst);
+}
+
+#[test]
+fn drop_invokes_drop_fn() {
+    {
+        let _kv = KVec {
+            ptr: core::ptr::null(),
+            len: 0,
+            capacity: 0,
+            kind: KIND_U8,
+            drop_fn: Some(mark_drop),
+        };
+    }
+    assert!(DROPPED.load(Ordering::SeqCst));
+}

--- a/crates/kayton_api/tests/vec_types_floats_test.rs
+++ b/crates/kayton_api/tests/vec_types_floats_test.rs
@@ -1,0 +1,25 @@
+use core::mem::size_of;
+use kayton_api::kinds::{KIND_F32, KIND_F64};
+use kayton_api::vec_types::KVec;
+
+#[test]
+fn from_vec_f32_roundtrip() {
+    let expected = vec![1.0f32, 2.5, 3.0];
+    let kv = KVec::from_vec_f32(expected.clone());
+    assert_eq!(kv.len, expected.len() * size_of::<f32>());
+    assert_eq!(kv.capacity, expected.capacity() * size_of::<f32>());
+    assert_eq!(kv.kind, KIND_F32);
+    let back = kv.as_vec_f32().unwrap();
+    assert_eq!(back, expected);
+}
+
+#[test]
+fn from_vec_f64_roundtrip() {
+    let expected = vec![1.0f64, 2.5, 3.0];
+    let kv = KVec::from_vec_f64(expected.clone());
+    assert_eq!(kv.len, expected.len() * size_of::<f64>());
+    assert_eq!(kv.capacity, expected.capacity() * size_of::<f64>());
+    assert_eq!(kv.kind, KIND_F64);
+    let back = kv.as_vec_f64().unwrap();
+    assert_eq!(back, expected);
+}

--- a/crates/kayton_api/tests/vec_types_signed_test.rs
+++ b/crates/kayton_api/tests/vec_types_signed_test.rs
@@ -1,0 +1,25 @@
+use core::mem::size_of;
+use kayton_api::kinds::{KIND_I128, KIND_I16, KIND_I32, KIND_I64, KIND_I8, KIND_ISIZE};
+use kayton_api::vec_types::KVec;
+
+macro_rules! test_signed {
+    ($name:ident, $t:ty, $from:ident, $as:ident, $kind:ident) => {
+        #[test]
+        fn $name() {
+            let expected: Vec<$t> = vec![1 as $t, 2 as $t, 3 as $t];
+            let kv = KVec::$from(expected.clone());
+            assert_eq!(kv.len, expected.len() * size_of::<$t>());
+            assert_eq!(kv.capacity, expected.capacity() * size_of::<$t>());
+            assert_eq!(kv.kind, $kind);
+            let back = kv.$as().unwrap();
+            assert_eq!(back, expected);
+        }
+    };
+}
+
+test_signed!(from_vec_i8_roundtrip, i8, from_vec_i8, as_vec_i8, KIND_I8);
+test_signed!(from_vec_i16_roundtrip, i16, from_vec_i16, as_vec_i16, KIND_I16);
+test_signed!(from_vec_i32_roundtrip, i32, from_vec_i32, as_vec_i32, KIND_I32);
+test_signed!(from_vec_i64_roundtrip, i64, from_vec_i64, as_vec_i64, KIND_I64);
+test_signed!(from_vec_i128_roundtrip, i128, from_vec_i128, as_vec_i128, KIND_I128);
+test_signed!(from_vec_isize_roundtrip, isize, from_vec_isize, as_vec_isize, KIND_ISIZE);

--- a/crates/kayton_api/tests/vec_types_unsigned_test.rs
+++ b/crates/kayton_api/tests/vec_types_unsigned_test.rs
@@ -1,0 +1,25 @@
+use core::mem::size_of;
+use kayton_api::kinds::{KIND_U128, KIND_U16, KIND_U32, KIND_U64, KIND_U8, KIND_USIZE};
+use kayton_api::vec_types::KVec;
+
+macro_rules! test_unsigned {
+    ($name:ident, $t:ty, $from:ident, $as:ident, $kind:ident) => {
+        #[test]
+        fn $name() {
+            let expected: Vec<$t> = vec![1 as $t, 2 as $t, 3 as $t];
+            let kv = KVec::$from(expected.clone());
+            assert_eq!(kv.len, expected.len() * size_of::<$t>());
+            assert_eq!(kv.capacity, expected.capacity() * size_of::<$t>());
+            assert_eq!(kv.kind, $kind);
+            let back = kv.$as().unwrap();
+            assert_eq!(back, expected);
+        }
+    };
+}
+
+test_unsigned!(from_vec_u8_roundtrip, u8, from_vec_u8, as_vec_u8, KIND_U8);
+test_unsigned!(from_vec_u16_roundtrip, u16, from_vec_u16, as_vec_u16, KIND_U16);
+test_unsigned!(from_vec_u32_roundtrip, u32, from_vec_u32, as_vec_u32, KIND_U32);
+test_unsigned!(from_vec_u64_roundtrip, u64, from_vec_u64, as_vec_u64, KIND_U64);
+test_unsigned!(from_vec_u128_roundtrip, u128, from_vec_u128, as_vec_u128, KIND_U128);
+test_unsigned!(from_vec_usize_roundtrip, usize, from_vec_usize, as_vec_usize, KIND_USIZE);


### PR DESCRIPTION
## Summary
- add roundtrip tests for boolean, float, signed, and unsigned KVec conversions
- verify KVec::from_raw and drop callback

## Testing
- `cargo test -p kayton_api`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68bd798b3e98832cb54a4f121a450a87