### PR TITLE
Add if/else control flow to Kayton compiler

### DIFF
--- a/crates/kayton_interactive_shared/src/lib.rs
+++ b/crates/kayton_interactive_shared/src/lib.rs
@@ -118,6 +118,20 @@ fn build_prelude_and_epilogue(
                     walk_stmt(s, used_syms, assigned_syms);
                 }
             }
+            RStmt::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                collect_expr_syms(cond, used_syms);
+                for s in then_branch {
+                    walk_stmt(s, used_syms, assigned_syms);
+                }
+                for s in else_branch {
+                    walk_stmt(s, used_syms, assigned_syms);
+                }
+            }
         }
     }
 

--- a/crates/keyton_rust_compiler/src/compile_rust/tests.rs
+++ b/crates/keyton_rust_compiler/src/compile_rust/tests.rs
@@ -117,6 +117,68 @@ fn compile_and_run_vec_append_sum() {
 }
 
 #[test]
+fn compile_and_run_if_else_true() {
+    let src = r#"x = True
+y = 0
+if x:
+    y = 1
+else:
+    y = 2
+print(y)
+"#;
+    let lib_path = compile_lang_source_to_dylib(src).expect("compile to dylib");
+    unsafe {
+        let lib = Library::new(&lib_path).expect("load dylib");
+        let set_reporters: libloading::Symbol<
+            unsafe extern "C" fn(
+                extern "C" fn(*const u8, usize, i64),
+                extern "C" fn(*const u8, usize, *const u8, usize),
+            ),
+        > = lib
+            .get(b"kayton_set_reporters")
+            .expect("find reporters symbol");
+        let run: libloading::Symbol<unsafe extern "C" fn()> =
+            lib.get(b"run").expect("find run symbol");
+        CAPTURED.lock().unwrap().clear();
+        set_reporters(report_int, report_str);
+        run();
+    }
+    let output = String::from_utf8(CAPTURED.lock().unwrap().clone()).expect("utf8");
+    assert_eq!(output.trim(), "1");
+}
+
+#[test]
+fn compile_and_run_if_else_false() {
+    let src = r#"x = False
+y = 0
+if x:
+    y = 1
+else:
+    y = 2
+print(y)
+"#;
+    let lib_path = compile_lang_source_to_dylib(src).expect("compile to dylib");
+    unsafe {
+        let lib = Library::new(&lib_path).expect("load dylib");
+        let set_reporters: libloading::Symbol<
+            unsafe extern "C" fn(
+                extern "C" fn(*const u8, usize, i64),
+                extern "C" fn(*const u8, usize, *const u8, usize),
+            ),
+        > = lib
+            .get(b"kayton_set_reporters")
+            .expect("find reporters symbol");
+        let run: libloading::Symbol<unsafe extern "C" fn()> =
+            lib.get(b"run").expect("find run symbol");
+        CAPTURED.lock().unwrap().clear();
+        set_reporters(report_int, report_str);
+        run();
+    }
+    let output = String::from_utf8(CAPTURED.lock().unwrap().clone()).expect("utf8");
+    assert_eq!(output.trim(), "2");
+}
+
+#[test]
 fn compile_and_run_typed_vec_append_sum() {
     let src = "a: Vec<i64> = []\na.append(2)\na.append(3)\nres = a.sum()\nprint(res)\n";
     let lib_path = compile_lang_source_to_dylib(src).expect("compile to dylib");

--- a/crates/keyton_rust_compiler/src/hir/hir_types.rs
+++ b/crates/keyton_rust_compiler/src/hir/hir_types.rs
@@ -19,6 +19,12 @@ pub enum HirStmt {
         end: HirExpr,
         body: Vec<HirStmt>,
     },
+    If {
+        hir_id: HirId,
+        cond: HirExpr,
+        then_branch: Vec<HirStmt>,
+        else_branch: Vec<HirStmt>,
+    },
     FuncDef {
         hir_id: HirId,
         name: String,
@@ -36,6 +42,10 @@ pub enum HirExpr {
     Str {
         hir_id: HirId,
         value: String,
+    },
+    Bool {
+        hir_id: HirId,
+        value: bool,
     },
     Ident {
         hir_id: HirId,

--- a/crates/keyton_rust_compiler/src/hir/mod.rs
+++ b/crates/keyton_rust_compiler/src/hir/mod.rs
@@ -54,6 +54,22 @@ fn lower_stmt(ctx: &mut LoweringCtx, stmt: Stmt) -> HirStmt {
             end: lower_expr(ctx, end),
             body: body.into_iter().map(|s| lower_stmt(ctx, s)).collect(),
         },
+        Stmt::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => HirStmt::If {
+            hir_id: ctx.new_id(),
+            cond: lower_expr(ctx, cond),
+            then_branch: then_branch
+                .into_iter()
+                .map(|s| lower_stmt(ctx, s))
+                .collect(),
+            else_branch: else_branch
+                .into_iter()
+                .map(|s| lower_stmt(ctx, s))
+                .collect(),
+        },
         Stmt::ExprStmt(expr) => HirStmt::ExprStmt {
             hir_id: ctx.new_id(),
             expr: lower_expr(ctx, expr),
@@ -81,6 +97,10 @@ fn lower_expr(ctx: &mut LoweringCtx, expr: Expr) -> HirExpr {
         Expr::Str(s) => HirExpr::Str {
             hir_id: ctx.new_id(),
             value: s,
+        },
+        Expr::Bool(b) => HirExpr::Bool {
+            hir_id: ctx.new_id(),
+            value: b,
         },
         Expr::Ident(s) => HirExpr::Ident {
             hir_id: ctx.new_id(),

--- a/crates/keyton_rust_compiler/src/lexer/mod.rs
+++ b/crates/keyton_rust_compiler/src/lexer/mod.rs
@@ -10,6 +10,10 @@ pub enum Token {
     LetKw,
     FnKw,
     ReturnKw,
+    IfKw,
+    ElseKw,
+    TrueKw,
+    FalseKw,
     Plus,
     Equal,
     LParen,
@@ -257,6 +261,10 @@ impl<'a> Lexer<'a> {
             "return" => Token::ReturnKw,
             "for" => Token::ForKw,
             "in" => Token::InKw,
+            "if" => Token::IfKw,
+            "else" => Token::ElseKw,
+            "True" => Token::TrueKw,
+            "False" => Token::FalseKw,
             _ => Token::Ident(ident),
         }
     }

--- a/crates/keyton_rust_compiler/src/rhir/converter.rs
+++ b/crates/keyton_rust_compiler/src/rhir/converter.rs
@@ -76,6 +76,23 @@ impl<'a> Converter<'a> {
                 end: self.convert_expr(end),
                 body: body.iter().map(|st| self.convert_stmt(st)).collect(),
             },
+            TStmt::If {
+                hir_id,
+                cond,
+                then_branch,
+                else_branch,
+            } => RStmt::If {
+                hir_id: *hir_id,
+                cond: self.convert_expr(cond),
+                then_branch: then_branch
+                    .iter()
+                    .map(|st| self.convert_stmt(st))
+                    .collect(),
+                else_branch: else_branch
+                    .iter()
+                    .map(|st| self.convert_stmt(st))
+                    .collect(),
+            },
         }
     }
 
@@ -89,6 +106,11 @@ impl<'a> Converter<'a> {
             TExpr::Str { hir_id, value, ty } => RExpr::Str {
                 hir_id: *hir_id,
                 value: value.clone(),
+                ty: ty.clone(),
+            },
+            TExpr::Bool { hir_id, value, ty } => RExpr::Bool {
+                hir_id: *hir_id,
+                value: *value,
                 ty: ty.clone(),
             },
             TExpr::Name { hir_id, sym, ty } => RExpr::Name {

--- a/crates/keyton_rust_compiler/src/rhir/types.rs
+++ b/crates/keyton_rust_compiler/src/rhir/types.rs
@@ -19,6 +19,12 @@ pub enum RStmt {
         end: RExpr,
         body: Vec<RStmt>,
     },
+    If {
+        hir_id: HirId,
+        cond: RExpr,
+        then_branch: Vec<RStmt>,
+        else_branch: Vec<RStmt>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -31,6 +37,11 @@ pub enum RExpr {
     Str {
         hir_id: HirId,
         value: String,
+        ty: Type,
+    },
+    Bool {
+        hir_id: HirId,
+        value: bool,
         ty: Type,
     },
     Name {
@@ -81,6 +92,7 @@ impl RExpr {
         match self {
             RExpr::Int { ty, .. }
             | RExpr::Str { ty, .. }
+            | RExpr::Bool { ty, .. }
             | RExpr::Name { ty, .. }
             | RExpr::Binary { ty, .. }
             | RExpr::Call { ty, .. }

--- a/crates/keyton_rust_compiler/src/rust_codegen/generator.rs
+++ b/crates/keyton_rust_compiler/src/rust_codegen/generator.rs
@@ -188,6 +188,38 @@ impl<'a> CodeGenerator<'a> {
                 out.push_str("}");
                 out
             }
+            RStmt::If {
+                cond,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                let cond_str = self.convert_expr_to_string(cond);
+                let mut out = String::new();
+                out.push_str(&format!("if {} {{\n", cond_str));
+                for inner in then_branch {
+                    if self.should_skip_stmt(inner) {
+                        continue;
+                    }
+                    out.push_str("    ");
+                    out.push_str(&self.convert_stmt_to_string(inner));
+                    out.push_str("\n");
+                }
+                out.push_str("}");
+                if !else_branch.is_empty() {
+                    out.push_str(" else {\n");
+                    for inner in else_branch {
+                        if self.should_skip_stmt(inner) {
+                            continue;
+                        }
+                        out.push_str("    ");
+                        out.push_str(&self.convert_stmt_to_string(inner));
+                        out.push_str("\n");
+                    }
+                    out.push_str("}");
+                }
+                out
+            }
         }
     }
 
@@ -205,6 +237,7 @@ impl<'a> CodeGenerator<'a> {
         match expr {
             RExpr::Int { value, .. } => value.to_string(),
             RExpr::Str { value, .. } => format!("\"{}\"", value),
+            RExpr::Bool { value, .. } => value.to_string(),
             RExpr::Name { sym, .. } => self.get_or_create_var_name(*sym),
             RExpr::Binary {
                 left, op, right, ..

--- a/crates/keyton_rust_compiler/src/shir/types.rs
+++ b/crates/keyton_rust_compiler/src/shir/types.rs
@@ -19,6 +19,12 @@ pub enum SStmt {
         end: SExpr,
         body: Vec<SStmt>,
     },
+    If {
+        hir_id: HirId,
+        cond: SExpr,
+        then_branch: Vec<SStmt>,
+        else_branch: Vec<SStmt>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -30,6 +36,10 @@ pub enum SExpr {
     Str {
         hir_id: HirId,
         value: String,
+    },
+    Bool {
+        hir_id: HirId,
+        value: bool,
     },
     Name {
         hir_id: HirId,

--- a/crates/keyton_rust_compiler/src/thir/checker.rs
+++ b/crates/keyton_rust_compiler/src/thir/checker.rs
@@ -133,6 +133,23 @@ impl<'a> Checker<'a> {
                     body: body_t,
                 }
             }
+            SStmt::If {
+                hir_id,
+                cond,
+                then_branch,
+                else_branch,
+            } => {
+                let tcond = self.check_expr(cond);
+                // For now, accept any type for condition
+                let then_t: Vec<TStmt> = then_branch.iter().map(|st| self.check_stmt(st)).collect();
+                let else_t: Vec<TStmt> = else_branch.iter().map(|st| self.check_stmt(st)).collect();
+                TStmt::If {
+                    hir_id: *hir_id,
+                    cond: tcond,
+                    then_branch: then_t,
+                    else_branch: else_t,
+                }
+            }
         }
     }
 
@@ -147,6 +164,11 @@ impl<'a> Checker<'a> {
                 hir_id: *hir_id,
                 value: value.clone(),
                 ty: Type::Str,
+            },
+            SExpr::Bool { hir_id, value } => TExpr::Bool {
+                hir_id: *hir_id,
+                value: *value,
+                ty: Type::Any,
             },
             SExpr::Name { hir_id, sym } => {
                 let var_name = &self.symbols.infos[sym.0 as usize].name;
@@ -337,6 +359,7 @@ impl TExpr {
         match self {
             TExpr::Int { ty, .. }
             | TExpr::Str { ty, .. }
+            | TExpr::Bool { ty, .. }
             | TExpr::Name { ty, .. }
             | TExpr::Binary { ty, .. }
             | TExpr::Call { ty, .. }

--- a/crates/keyton_rust_compiler/src/thir/types.rs
+++ b/crates/keyton_rust_compiler/src/thir/types.rs
@@ -19,6 +19,12 @@ pub enum TStmt {
         end: TExpr,
         body: Vec<TStmt>,
     },
+    If {
+        hir_id: HirId,
+        cond: TExpr,
+        then_branch: Vec<TStmt>,
+        else_branch: Vec<TStmt>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -31,6 +37,11 @@ pub enum TExpr {
     Str {
         hir_id: HirId,
         value: String,
+        ty: Type,
+    },
+    Bool {
+        hir_id: HirId,
+        value: bool,
         ty: Type,
     },
     Name {


### PR DESCRIPTION
## Summary
- support `if`/`else` statements and boolean literals across the Kayton compiler pipeline
- generate Rust `if` blocks and handle boolean expressions
- add tests ensuring `if` evaluates correctly for `True` and `False`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68bd88144fb8832cbe0eb50f3d8cdc2f