### PR TITLE
Add CLI tests for kik

### DIFF
--- a/crates/kik/tests/cli_tests.rs
+++ b/crates/kik/tests/cli_tests.rs
@@ -1,0 +1,39 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+
+#[test]
+fn uninstall_reports_unimplemented() {
+    let mut cmd = Command::cargo_bin("kik").unwrap();
+    cmd.args(["uninstall", "demo-crate"]);
+    cmd.assert()
+        .failure()
+        .stderr(contains("Not yet implemented: uninstall demo-crate"));
+}
+
+#[test]
+fn kernel_install_reports_unimplemented_with_custom_name() {
+    let mut cmd = Command::cargo_bin("kik").unwrap();
+    cmd.args(["kernel", "install", "--name", "custom"]);
+    cmd.assert()
+        .failure()
+        .stderr(contains("Not yet implemented: kernel install (name='custom')"));
+}
+
+#[test]
+fn kernel_install_reports_unimplemented_with_default_name() {
+    let mut cmd = Command::cargo_bin("kik").unwrap();
+    cmd.args(["kernel", "install"]);
+    cmd.assert()
+        .failure()
+        .stderr(contains("Not yet implemented: kernel install (name='kayton')"));
+}
+
+#[test]
+fn displays_help() {
+    Command::cargo_bin("kik")
+        .unwrap()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(contains("Kayton environment manager"));
+}


### PR DESCRIPTION
## Summary
- add integration tests covering `kik` CLI help and unimplemented subcommands

## Testing
- `cargo test -p kik --test cli_tests`
- `cargo nextest run --status-level=fail`


------
https://chatgpt.com/codex/tasks/task_e_68bdbf9a96ec832c92cd8133bb5f1eb9