### PR TITLE
Refactor print tests to value checks

### DIFF
--- a/crates/kayton_interactive_shared/tests/program_output_test.rs
+++ b/crates/kayton_interactive_shared/tests/program_output_test.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use kayton_interactive_shared::{InteractiveState, execute_prepared, prepare_input};
 
 #[test]
-fn program_prints_and_last_expr_matches_expected() -> Result<()> {
+fn program_values_match_expected() -> Result<()> {
     let mut state = InteractiveState::new();
 
     // Execute the entire program in one block, mirroring a single Jupyter cell
@@ -11,9 +11,47 @@ fn program_prints_and_last_expr_matches_expected() -> Result<()> {
 a=1
 b=2
 z = my(a,b)
-print(z)
-print(a)
 z"#;
+    let prepared = prepare_input(&mut state, code)?;
+    execute_prepared(&mut state, &prepared)?;
+
+    // Fetch values directly from the VM rather than relying on printed output
+    let z_text = if let Some(h) = state.vm().resolve_name("z") {
+        state.vm_mut().format_value_by_handle(h).unwrap_or_default()
+    } else {
+        String::new()
+    };
+    assert_eq!(z_text, "3");
+
+    let a_text = if let Some(h) = state.vm().resolve_name("a") {
+        state.vm_mut().format_value_by_handle(h).unwrap_or_default()
+    } else {
+        String::new()
+    };
+    assert_eq!(a_text, "1");
+
+    // Verify that the last expression value is captured into __last
+    let last_text = if let Some(h) = state.vm().resolve_name("__last") {
+        state.vm_mut().format_value_by_handle(h).unwrap_or_default()
+    } else {
+        String::new()
+    };
+    assert_eq!(last_text, "3");
+
+    Ok(())
+}
+
+#[test]
+fn print_outputs_all_values() -> Result<()> {
+    let mut state = InteractiveState::new();
+
+    let code = r#"fn my(a,b):
+    a+b
+a=1
+b=2
+z = my(a,b)
+print(z)
+print(a)"#;
     let prepared = prepare_input(&mut state, code)?;
     execute_prepared(&mut state, &prepared)?;
 
@@ -24,16 +62,7 @@ z"#;
     } else {
         String::new()
     };
-
     assert_eq!(text, "3\n1");
-
-    // Verify that the last expression value is captured into __last
-    let last_text = if let Some(h) = state.vm().resolve_name("__last") {
-        state.vm_mut().format_value_by_handle(h).unwrap_or_default()
-    } else {
-        String::new()
-    };
-    assert_eq!(last_text, "3");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- avoid relying on printed output in kayton_interactive_shared and kayton_repl tests
- add consolidated print tests verifying stdout for both crates

## Testing
- `cargo test`
- `cargo nextest run --status-level=fail`


------
https://chatgpt.com/codex/tasks/task_e_68bdcc7b89d0832c92993a283fe881b5