### PR TITLE
refactor tests

### DIFF
--- a/crates/keyton_rust_compiler/src/compile_rust/tests.rs
+++ b/crates/keyton_rust_compiler/src/compile_rust/tests.rs
@@ -2,31 +2,107 @@ use super::*;
 use libloading::Library;
 use std::sync::Mutex;
 
+static CAPTURED_STDOUT: Mutex<Vec<u8>> = Mutex::new(Vec::new());
+static CAPTURED_LAST_INT: Mutex<Option<i64>> = Mutex::new(None);
+
+extern "C" fn report_int(name_ptr: *const u8, name_len: usize, value: i64) {
+    unsafe {
+        let name =
+            std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)).unwrap_or("");
+        if name == "__last" {
+            CAPTURED_LAST_INT.lock().unwrap().replace(value);
+        }
+    }
+}
+
+extern "C" fn report_str(name_ptr: *const u8, name_len: usize, str_ptr: *const u8, str_len: usize) {
+    unsafe {
+        let name =
+            std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)).unwrap_or("");
+        let s = std::slice::from_raw_parts(str_ptr, str_len);
+        if name == "__stdout" {
+            CAPTURED_STDOUT.lock().unwrap().extend_from_slice(s);
+        } else if name == "__last" {
+            CAPTURED_STDOUT.lock().unwrap().extend_from_slice(s);
+        }
+    }
+}
+
+fn take_last_int() -> i64 {
+    if let Some(v) = CAPTURED_LAST_INT.lock().unwrap().take() {
+        return v;
+    }
+    let s = {
+        let mut lock = CAPTURED_STDOUT.lock().unwrap();
+        let s = String::from_utf8(lock.clone()).expect("utf8");
+        lock.clear();
+        s
+    };
+    s.trim().parse().expect("int")
+}
+
 #[test]
-fn compile_and_run_print() {
-    let src = r#"print("Hello from dylib")"#;
+fn compile_and_run_print_all_values() {
+    let src = r#"print("Hello from dylib")
+x = 12
+x = x + 30
+print(x)
+fn my_sum(x, y):
+    x + y
+print(my_sum(1,2))"#;
     let lib_path = compile_lang_source_to_dylib(src).expect("compile to dylib");
     unsafe {
         let lib = Library::new(&lib_path).expect("load dylib");
-        let func: libloading::Symbol<unsafe extern "C" fn()> =
+        let set_reporters: libloading::Symbol<
+            unsafe extern "C" fn(
+                extern "C" fn(*const u8, usize, i64),
+                extern "C" fn(*const u8, usize, *const u8, usize),
+            ),
+        > = lib
+            .get(b"kayton_set_reporters")
+            .expect("find reporters symbol");
+        let run: libloading::Symbol<unsafe extern "C" fn()> =
             lib.get(b"run").expect("find run symbol");
-        func();
+        CAPTURED_STDOUT.lock().unwrap().clear();
+        CAPTURED_LAST_INT.lock().unwrap().take();
+        set_reporters(report_int, report_str);
+        run();
     }
+    let output = {
+        let mut lock = CAPTURED_STDOUT.lock().unwrap();
+        let s = String::from_utf8(lock.clone()).expect("utf8");
+        lock.clear();
+        s
+    };
+    assert_eq!(output.trim_end(), "Hello from dylib\n42\n3");
 }
 
 #[test]
 fn compile_and_run_math() {
     let src = r#"x = 12
 x = x + 30
-print(x)
+x
 "#;
     let lib_path = compile_lang_source_to_dylib(src).expect("compile to dylib");
     unsafe {
         let lib = Library::new(&lib_path).expect("load dylib");
-        let func: libloading::Symbol<unsafe extern "C" fn()> =
+        let set_reporters: libloading::Symbol<
+            unsafe extern "C" fn(
+                extern "C" fn(*const u8, usize, i64),
+                extern "C" fn(*const u8, usize, *const u8, usize),
+            ),
+        > = lib
+            .get(b"kayton_set_reporters")
+            .expect("find reporters symbol");
+        let run: libloading::Symbol<unsafe extern "C" fn()> =
             lib.get(b"run").expect("find run symbol");
-        func();
+        CAPTURED_STDOUT.lock().unwrap().clear();
+        CAPTURED_LAST_INT.lock().unwrap().take();
+        set_reporters(report_int, report_str);
+        run();
     }
+    let value = take_last_int();
+    assert_eq!(value, 42);
 }
 
 #[test]
@@ -38,30 +114,28 @@ fn my_sum(x, y):
     x + y
 
 z = my_sum(x,y)
-print(z)
+z
 "#;
     let lib_path = compile_lang_source_to_dylib(src).expect("compile to dylib");
     unsafe {
         let lib = Library::new(&lib_path).expect("load dylib");
-        let func: libloading::Symbol<unsafe extern "C" fn()> =
+        let set_reporters: libloading::Symbol<
+            unsafe extern "C" fn(
+                extern "C" fn(*const u8, usize, i64),
+                extern "C" fn(*const u8, usize, *const u8, usize),
+            ),
+        > = lib
+            .get(b"kayton_set_reporters")
+            .expect("find reporters symbol");
+        let run: libloading::Symbol<unsafe extern "C" fn()> =
             lib.get(b"run").expect("find run symbol");
-        func();
+        CAPTURED_STDOUT.lock().unwrap().clear();
+        CAPTURED_LAST_INT.lock().unwrap().take();
+        set_reporters(report_int, report_str);
+        run();
     }
-}
-
-static CAPTURED: Mutex<Vec<u8>> = Mutex::new(Vec::new());
-
-extern "C" fn report_int(_name_ptr: *const u8, _name_len: usize, _value: i64) {}
-
-extern "C" fn report_str(name_ptr: *const u8, name_len: usize, str_ptr: *const u8, str_len: usize) {
-    unsafe {
-        let name =
-            std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)).unwrap_or("");
-        if name == "__stdout" {
-            let s = std::slice::from_raw_parts(str_ptr, str_len);
-            CAPTURED.lock().unwrap().extend_from_slice(s);
-        }
-    }
+    let value = take_last_int();
+    assert_eq!(value, 3);
 }
 
 #[test]
@@ -69,7 +143,7 @@ fn compile_and_run_for_loop_sum() {
     let src = r#"s = 0
 for x in 0..3:
     s += x
-print(s)
+s
 "#;
     let lib_path = compile_lang_source_to_dylib(src).expect("compile to dylib");
     unsafe {
@@ -84,17 +158,18 @@ print(s)
             .expect("find reporters symbol");
         let run: libloading::Symbol<unsafe extern "C" fn()> =
             lib.get(b"run").expect("find run symbol");
-        CAPTURED.lock().unwrap().clear();
+        CAPTURED_STDOUT.lock().unwrap().clear();
+        CAPTURED_LAST_INT.lock().unwrap().take();
         set_reporters(report_int, report_str);
         run();
     }
-    let output = String::from_utf8(CAPTURED.lock().unwrap().clone()).expect("utf8");
-    assert_eq!(output.trim(), "3");
+    let value = take_last_int();
+    assert_eq!(value, 3);
 }
 
 #[test]
 fn compile_and_run_vec_append_sum() {
-    let src = "a = []\na.append(2)\na.append(3)\nres = a.sum()\nprint(res)\n";
+    let src = "a = []\na.append(2)\na.append(3)\nres = a.sum()\nres\n";
     let lib_path = compile_lang_source_to_dylib(src).expect("compile to dylib");
     unsafe {
         let lib = Library::new(&lib_path).expect("load dylib");
@@ -108,12 +183,13 @@ fn compile_and_run_vec_append_sum() {
             .expect("find reporters symbol");
         let run: libloading::Symbol<unsafe extern "C" fn()> =
             lib.get(b"run").expect("find run symbol");
-        CAPTURED.lock().unwrap().clear();
+        CAPTURED_STDOUT.lock().unwrap().clear();
+        CAPTURED_LAST_INT.lock().unwrap().take();
         set_reporters(report_int, report_str);
         run();
     }
-    let output = String::from_utf8(CAPTURED.lock().unwrap().clone()).expect("utf8");
-    assert_eq!(output.trim(), "5");
+    let value = take_last_int();
+    assert_eq!(value, 5);
 }
 
 #[test]
@@ -124,7 +200,7 @@ if x:
     y = 1
 else:
     y = 2
-print(y)
+y
 "#;
     let lib_path = compile_lang_source_to_dylib(src).expect("compile to dylib");
     unsafe {
@@ -139,12 +215,13 @@ print(y)
             .expect("find reporters symbol");
         let run: libloading::Symbol<unsafe extern "C" fn()> =
             lib.get(b"run").expect("find run symbol");
-        CAPTURED.lock().unwrap().clear();
+        CAPTURED_STDOUT.lock().unwrap().clear();
+        CAPTURED_LAST_INT.lock().unwrap().take();
         set_reporters(report_int, report_str);
         run();
     }
-    let output = String::from_utf8(CAPTURED.lock().unwrap().clone()).expect("utf8");
-    assert_eq!(output.trim(), "1");
+    let value = take_last_int();
+    assert_eq!(value, 1);
 }
 
 #[test]
@@ -155,7 +232,7 @@ if x:
     y = 1
 else:
     y = 2
-print(y)
+y
 "#;
     let lib_path = compile_lang_source_to_dylib(src).expect("compile to dylib");
     unsafe {
@@ -170,17 +247,18 @@ print(y)
             .expect("find reporters symbol");
         let run: libloading::Symbol<unsafe extern "C" fn()> =
             lib.get(b"run").expect("find run symbol");
-        CAPTURED.lock().unwrap().clear();
+        CAPTURED_STDOUT.lock().unwrap().clear();
+        CAPTURED_LAST_INT.lock().unwrap().take();
         set_reporters(report_int, report_str);
         run();
     }
-    let output = String::from_utf8(CAPTURED.lock().unwrap().clone()).expect("utf8");
-    assert_eq!(output.trim(), "2");
+    let value = take_last_int();
+    assert_eq!(value, 2);
 }
 
 #[test]
 fn compile_and_run_typed_vec_append_sum() {
-    let src = "a: Vec<i64> = []\na.append(2)\na.append(3)\nres = a.sum()\nprint(res)\n";
+    let src = "a: Vec<i64> = []\na.append(2)\na.append(3)\nres = a.sum()\nres\n";
     let lib_path = compile_lang_source_to_dylib(src).expect("compile to dylib");
     unsafe {
         let lib = Library::new(&lib_path).expect("load dylib");
@@ -194,10 +272,11 @@ fn compile_and_run_typed_vec_append_sum() {
             .expect("find reporters symbol");
         let run: libloading::Symbol<unsafe extern "C" fn()> =
             lib.get(b"run").expect("find run symbol");
-        CAPTURED.lock().unwrap().clear();
+        CAPTURED_STDOUT.lock().unwrap().clear();
+        CAPTURED_LAST_INT.lock().unwrap().take();
         set_reporters(report_int, report_str);
         run();
     }
-    let output = String::from_utf8(CAPTURED.lock().unwrap().clone()).expect("utf8");
-    assert_eq!(output.trim(), "5");
+    let value = take_last_int();
+    assert_eq!(value, 5);
 }

--- a/crates/keyton_rust_compiler/src/rust_codegen/generator.rs
+++ b/crates/keyton_rust_compiler/src/rust_codegen/generator.rs
@@ -496,6 +496,16 @@ impl<'a> CodeGenerator<'a> {
 }
 
 pub fn generate_rust_code(rhir_program: &RustProgram, resolved: &ResolvedProgram) -> RustCode {
+    use std::collections::HashSet;
+
     let mut generator = CodeGenerator::new(resolved);
-    generator.generate_code(rhir_program)
+    let pre_assigned: HashSet<SymbolId> = HashSet::new();
+    let prelude: Vec<String> = Vec::new();
+    let epilogue: Vec<String> = Vec::new();
+    generator.generate_code_with_preassigned_and_prelude(
+        rhir_program,
+        &pre_assigned,
+        &prelude,
+        &epilogue,
+    )
 }


### PR DESCRIPTION
## Summary
- consolidate print tests into one and assert on value outputs
- capture `__last` without printing across compile tests
- ensure Rust codegen reports last expression value for tests

## Testing
- `cargo nextest run --status-level=fail`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bde0f7e6e8832cbab38f01fa2c70c3